### PR TITLE
Taximarkerfix

### DIFF
--- a/scripts/module/taxi_stunting.nut
+++ b/scripts/module/taxi_stunting.nut
@@ -61,7 +61,7 @@ function createVisual(player, duration) {
   height_cp[player.ID] = CreateCheckpoint(player, player.UniqueWorld, false,
 					  height_record_position, ARGB(255, 255, 0, 0), 4);
   height_ma[player.ID] = CreateMarker(player.UniqueWorld, height_record_position,
-				      5, RGB(255, 255, 0), 26 );
+				      5, RGB(255, 0, 0), 0 );
 
   height_cp_timer[player.ID] = NewTimer("removeVisual", duration, 1, player.ID);
 }


### PR DESCRIPTION
Requires #1 .

Set the taxi jump record marker to the `0` rectangle blip symbol.
This makes it possible to get a feel for how high it is by just looking at the radar.