### PR TITLE
spectate: Remove spawned check for spectator

### DIFF
--- a/scripts/module/spectate.nut
+++ b/scripts/module/spectate.nut
@@ -1,8 +1,8 @@
 function onKeyDown( player, key ) {
 
-  if(player.Spawned) {
-    return;
-  }
+//  if(player.Spawned) {
+//    return;
+//  }
 
   if ( key == BIND_SPEC_NEXT ) {
     if( player.SpectateTarget != null) {


### PR DESCRIPTION
Closes #14 

Spectator lag/camera choppiness/dumbstuff is not in our reach as it's part of VC-MP itself. This removes the requirement for the spectator to be in a non-playing state.
Controls are, just like before, F1 to toggle spectator mode and Left/Right to browse the players.