### PR TITLE
Set ramp opacity

### DIFF
--- a/scripts/module/ramp.nut
+++ b/scripts/module/ramp.nut
@@ -1,14 +1,18 @@
 //
 
 function onScriptLoad() {
-  RampObj <- array( 100, null );
+  PublicRamps <- array( 100, null );
+  PrivateRamps <- array( 100, null );
 }
 
 function onPlayerGameKeysChange( player, oldKey, newKey ) {
 
   if ( newKey & KEY_ONFOOT_FIRE && player.VehicleSlot==-1 ) {
-    if ( RampObj[player.ID] ) {
-      RampObj[player.ID].Delete();
+    if ( PublicRamps[player.ID] ) {
+      PublicRamps[player.ID].Delete();
+    }
+    if ( PrivateRamps[player.ID] ) {
+      PrivateRamps[player.ID].Delete();
     }
     local v = player.Vehicle;
     local pos;
@@ -24,22 +28,31 @@ function onPlayerGameKeysChange( player, oldKey, newKey ) {
       angle2 = Vector(0, 0, angle);
     }
     pos = GetForwardPoint( pos, angle, 10.0 );
-    local obj = CreateObject( 562, player.World, pos, 220 );
-    obj.RotateToEuler(angle2, 0);
-    RampObj[player.ID] = obj;
+    local publicRampObj = CreateObject( 562, player.World, pos, 150 );
+    local privateRampObj = CreateObject( 562, player.UniqueWorld, pos, 255 );
+    publicRampObj.RotateToEuler(angle2, 0);
+    privateRampObj.RotateToEuler(angle2, 0);
+    PublicRamps[player.ID] = publicRampObj;
+    PrivateRamps[player.ID] = privateRampObj;
   }
 
   if ( newKey & KEY_ONFOOT_AIM && player.VehicleSlot==-1 ) {
-    if ( RampObj[player.ID] ) {
-      RampObj[player.ID].Delete();
+    if ( PublicRamps[player.ID] ) {
+      PublicRamps[player.ID].Delete();
+    }
+    if ( PrivateRamps[player.ID] ) {
+      PrivateRamps[player.ID].Delete();
     }
   }
 }
 
 function onPlayerPart( player, reason ) {
   local id = player.ID;
-  if (RampObj[id]) {
-    RampObj[id].Delete();
+  if (PublicRamps[id]) {
+    PublicRamps[id].Delete();
+  }
+  if ( PrivateRamps[id] ) {
+    PrivateRamps[id].Delete();
   }
 }
 


### PR DESCRIPTION
Add a second set of ramps for opacity management.
Set the players UniqueWorld ramp at full opacity to make it distinguishable from the "public" ramp with a slight transparency.

Closes #35